### PR TITLE
Fixed bad file reference in the .pkg file 

### DIFF
--- a/statastan.pkg
+++ b/statastan.pkg
@@ -21,7 +21,7 @@ f windowsmonitor.ado
 f inline-opondo.do
 f inline-thompson.do
 f stan_schools_example.do
-f stan_example.do
+f stan-example.do
 f stan.sthlp
 f windowsmonitor.sthlp
 f stan_schools.sthlp


### PR DESCRIPTION
```
. net inst statastan, from("http://mc-stan.org/statastan/")
checking statastan consistency and verifying not already installed...
installing into /Users/billy/Library/Application Support/Stata/ado/plus/...
installation complete.

. net get statastan, from("http://mc-stan.org/statastan/")
checking statastan consistency and verifying not already installed...
file http://mc-stan.org/statastan/stan_example.do not found
could not copy http://mc-stan.org/statastan/stan_example.do
(no action taken)
```

Corrected the filename in the .pkg file to use stan-example.do.  This should fix the broken net get.
